### PR TITLE
Replace manual command checking with `regex.Matcher`

### DIFF
--- a/src/main/java/command/CommandDeleteHandler.java
+++ b/src/main/java/command/CommandDeleteHandler.java
@@ -2,31 +2,32 @@ package command;
 
 import data.TaskList;
 import data.tasks.Task;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.MatchResult;
+import java.util.regex.Pattern;
+
 import util.CommandUtils;
 
 public class CommandDeleteHandler extends CommandHandler {
 
-    CommandDeleteHandler(TaskList taskList) {
-        super(taskList);
-    }
+    private static final Pattern commandRegexPattern = Pattern.compile("^delete (\\d+)");
 
-    @Override
-    public boolean validateCommand(List<String> commandTokens) {
-        // There must be a task index followed by the `delete` command
-        return commandTokens.size() == 2;
-    }
-
-    @Override
-    public List<String> run(List<String> commandTokens) throws CommandException {
-        if (!validateCommand(commandTokens)) {
-            throw new CommandException("The `delete` command only expects 1 parameter!");
+    CommandDeleteHandler(String commandStr) throws CommandException {
+        super(commandStr, commandRegexPattern);
+        if (!isCommandValid()) {
+            throw new CommandException(
+                "`delete` command expects a single number argument (e.g. `delete 1`)");
         }
+    }
 
+    @Override
+    public List<String> run(TaskList taskList) throws CommandException {
         List<String> responseList = new ArrayList<>();
 
-        String taskIdxStr = commandTokens.get(1);
+        MatchResult regexMatchResult = commandRegexMatcher.toMatchResult();
+        String taskIdxStr = regexMatchResult.group(1);
         try {
             int taskIdx = Integer.parseInt(taskIdxStr);
             if (taskIdx <= 0 || taskIdx > taskList.size()) {
@@ -37,7 +38,8 @@ public class CommandDeleteHandler extends CommandHandler {
                     taskList.size()));
             }
         } catch (NumberFormatException error) {
-            throw new CommandException("Invalid task selected!");
+            throw new CommandException(
+                String.format("`delete` expects a number argument. Got: %s", taskIdxStr));
         }
 
         return responseList;

--- a/src/main/java/command/CommandFactory.java
+++ b/src/main/java/command/CommandFactory.java
@@ -5,28 +5,30 @@ import data.TaskList;
 public class CommandFactory {
 
     public Command parseCommand(String commandStr) throws CommandException {
+        String commandToken = commandStr.split(" ")[0];
         try {
-            return Command.valueOf(commandStr.toUpperCase());
+            return Command.valueOf(commandToken.toUpperCase());
         } catch (IllegalArgumentException error) {
             throw new CommandException("Unknown command!");
         }
     }
 
-    public CommandHandler getCommandHandler(Command command, TaskList taskList) {
+    public CommandHandler getCommandHandler(Command command, String commandStr)
+        throws CommandException {
         switch (command) {
             case LIST:
-                return new CommandListHandler(taskList);
+                return new CommandListHandler(commandStr);
             case MARK:
             case UNMARK:
-                return new CommandMarkHandler(taskList);
+                return new CommandMarkHandler(commandStr);
             case TODO:
-                return new CommandTodoHandler(taskList);
+                return new CommandTodoHandler(commandStr);
             case DEADLINE:
-                return new CommandDeadlineHandler(taskList);
+                return new CommandDeadlineHandler(commandStr);
             case EVENT:
-                return new CommandEventHandler(taskList);
+                return new CommandEventHandler(commandStr);
             case DELETE:
-                return new CommandDeleteHandler(taskList);
+                return new CommandDeleteHandler(commandStr);
         }
 
         return null;

--- a/src/main/java/command/CommandHandler.java
+++ b/src/main/java/command/CommandHandler.java
@@ -2,21 +2,24 @@ package command;
 
 import data.TaskList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public abstract class CommandHandler {
 
-    protected final TaskList taskList;
+    protected final String commandStr;
+    protected final Pattern commandRegexPattern;
+    protected final Matcher commandRegexMatcher;
 
-    public CommandHandler(TaskList taskList) {
-        this.taskList = taskList;
+    public CommandHandler(String commandStr, Pattern commandRegexPattern) {
+        this.commandStr = commandStr;
+        this.commandRegexPattern = commandRegexPattern;
+        this.commandRegexMatcher = commandRegexPattern.matcher(commandStr);
     }
 
-    protected static String gatherCommandTokens(List<String> tokens, int start, int end,
-        String delimiter) {
-        return String.join(delimiter, tokens.subList(start, end));
+    protected boolean isCommandValid() {
+        return commandRegexMatcher.find();
     }
 
-    abstract public boolean validateCommand(List<String> commandTokens);
-
-    abstract public List<String> run(List<String> commandTokens) throws CommandException;
+    abstract public List<String> run(TaskList taskList) throws CommandException;
 }

--- a/src/main/java/command/CommandListHandler.java
+++ b/src/main/java/command/CommandListHandler.java
@@ -1,27 +1,24 @@
 package command;
 
 import data.TaskList;
+
 import java.util.List;
 import java.util.ArrayList;
+import java.util.regex.Pattern;
 
 public class CommandListHandler extends CommandHandler {
 
-    public CommandListHandler(TaskList taskList) {
-        super(taskList);
-    }
+    private static final Pattern commandRegexPattern = Pattern.compile("^list$");
 
-    @Override
-    public boolean validateCommand(List<String> commandTokens) {
-        // There should only be a `list` command
-        return commandTokens.size() == 1;
-    }
-
-    @Override
-    public List<String> run(List<String> commandTokens) throws CommandException{
-        if (!validateCommand(commandTokens)) {
-            throw new CommandException("The `list` command expects no parameters!");
+    public CommandListHandler(String commandStr) throws CommandException {
+        super(commandStr, commandRegexPattern);
+        if (!isCommandValid()) {
+            throw new CommandException("`list` command expects no arguments!");
         }
+    }
 
+    @Override
+    public List<String> run(TaskList taskList) {
         List<String> responseList = new ArrayList<>();
 
         if (taskList.isEmpty()) {

--- a/src/main/java/command/CommandMarkHandler.java
+++ b/src/main/java/command/CommandMarkHandler.java
@@ -4,39 +4,35 @@ import data.TaskList;
 import data.tasks.Task;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.MatchResult;
+import java.util.regex.Pattern;
 
 public class CommandMarkHandler extends CommandHandler {
 
-    CommandMarkHandler(TaskList taskList) {
-        super(taskList);
-    }
+    private static final Pattern commandRegexPattern = Pattern.compile("^(u?n?mark) (\\d+)");
 
-    private boolean toMark(List<String> commandTokens) {
-        return commandTokens.get(0).toUpperCase().equals(Command.MARK.toString());
-    }
-
-    @Override
-    public boolean validateCommand(List<String> commandTokens) {
-        // There must be a task index followed by the `mark`/`unmark` command
-        return commandTokens.size() == 2;
-    }
-
-    @Override
-    public List<String> run(List<String> commandTokens) throws CommandException{
-        if (!validateCommand(commandTokens)) {
-            throw new CommandException("The `mark` command only expects 1 parameter!");
+    CommandMarkHandler(String commandStr) throws CommandException {
+        super(commandStr, commandRegexPattern);
+        if (!isCommandValid()) {
+            throw new CommandException(
+                "`mark`/`unmark` command expects a single number argument (e.g. `mark 1`, `unmark 2`)");
         }
+    }
 
+    @Override
+    public List<String> run(TaskList taskList) throws CommandException {
         List<String> responseList = new ArrayList<>();
+        MatchResult regexMatchResult = commandRegexMatcher.toMatchResult();
 
-        String taskIdxStr = commandTokens.get(1);
+        boolean toMark = regexMatchResult.group(1).equals("mark");
+        String taskIdxStr = regexMatchResult.group(2);
         try {
             int taskIdx = Integer.parseInt(taskIdxStr);
             if (taskIdx <= 0 || taskIdx > taskList.size()) {
                 throw new CommandException("Invalid task selected!");
             } else {
                 Task task = taskList.getTask(taskIdx - 1);
-                if (toMark(commandTokens)) {
+                if (toMark) {
                     task.mark();
                     responseList.add("Nice! I've mark this task as done:");
                 } else {
@@ -46,7 +42,8 @@ public class CommandMarkHandler extends CommandHandler {
                 responseList.add(String.format("\t%s", task));
             }
         } catch (NumberFormatException error) {
-            throw new CommandException("Invalid task selected!");
+            throw new CommandException(
+                String.format("`mark`/`unmark` expects a number argument. Got: %s", taskIdxStr));
         }
 
         return responseList;

--- a/src/main/java/command/CommandTodoHandler.java
+++ b/src/main/java/command/CommandTodoHandler.java
@@ -2,29 +2,31 @@ package command;
 
 import data.TaskList;
 import data.tasks.TaskTodo;
+
 import java.util.List;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import util.CommandUtils;
 
 public class CommandTodoHandler extends CommandHandler {
 
-    CommandTodoHandler(TaskList taskList) {
-        super(taskList);
-    }
+    private static final Pattern commandRegexPattern = Pattern.compile("^todo (.+)");
 
-    @Override
-    public boolean validateCommand(List<String> commandTokens) {
-        // Ensure there is a description after `todo` command
-        return commandTokens.size() > 1;
-    }
-
-    @Override
-    public List<String> run(List<String> commandTokens) throws CommandException {
-        if (!validateCommand(commandTokens)) {
-            throw new CommandException("The `todo` command expects a description!");
+    CommandTodoHandler(String commandStr) throws CommandException {
+        super(commandStr, commandRegexPattern);
+        if (!isCommandValid()) {
+            throw new CommandException(
+                "`todo` command expects a description (`todo todo-task-title`)");
         }
+    }
 
-        TaskTodo todoTask = new TaskTodo(
-            gatherCommandTokens(commandTokens, 1, commandTokens.size(), " "));
+    @Override
+    public List<String> run(TaskList taskList) {
+        MatchResult regexMatchResult = commandRegexMatcher.toMatchResult();
+
+        TaskTodo todoTask = new TaskTodo(regexMatchResult.group(1));
         taskList.addTask(todoTask);
 
         return CommandUtils.generateAddTaskResponse(todoTask, taskList.size());

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -18,10 +18,10 @@
 	OOPS!!! Invalid task selected!
 	--------------------------------------------------
 	--------------------------------------------------
-	OOPS!!! Invalid task selected!
+	OOPS!!! `mark`/`unmark` command expects a single number argument (e.g. `mark 1`, `unmark 2`)
 	--------------------------------------------------
 	--------------------------------------------------
-	OOPS!!! Invalid task selected!
+	OOPS!!! `mark`/`unmark` command expects a single number argument (e.g. `mark 1`, `unmark 2`)
 	--------------------------------------------------
 	--------------------------------------------------
 	Got it. I've added this task:
@@ -29,7 +29,7 @@
 	Now you have 1 tasks in the list
 	--------------------------------------------------
 	--------------------------------------------------
-	OOPS!!! The `todo` command expects a description!
+	OOPS!!! `todo` command expects a description (`todo todo-task-title`)
 	--------------------------------------------------
 	--------------------------------------------------
 	Got it. I've added this task:
@@ -37,10 +37,10 @@
 	Now you have 2 tasks in the list
 	--------------------------------------------------
 	--------------------------------------------------
-	OOPS!!! Invalid parameters passed to `deadline` command! (Expected: deadline <task-title> /by <deadline>)
+	OOPS!!! Invalid `deadline` command format (expected: deadline deadline-title /by datetime)
 	--------------------------------------------------
 	--------------------------------------------------
-	OOPS!!! Invalid parameters passed to `deadline` command! (Expected: deadline <task-title> /by <deadline>)
+	OOPS!!! Invalid `deadline` command format (expected: deadline deadline-title /by datetime)
 	--------------------------------------------------
 	--------------------------------------------------
 	Got it. I've added this task:
@@ -48,10 +48,10 @@
 	Now you have 3 tasks in the list
 	--------------------------------------------------
 	--------------------------------------------------
-	OOPS!!! Invalid parameters passed to `event` command! (Expected: event <event-title> /at <timing>)
+	OOPS!!! Invalid `event` command format (expected: event event-title /at datetime)
 	--------------------------------------------------
 	--------------------------------------------------
-	OOPS!!! Invalid parameters passed to `event` command! (Expected: event <event-title> /at <timing>)
+	OOPS!!! Invalid `event` command format (expected: event event-title /at datetime)
 	--------------------------------------------------
 	--------------------------------------------------
 	OOPS!!! Invalid task selected!
@@ -107,7 +107,7 @@
 	OOPS!!! Invalid task selected!
 	--------------------------------------------------
 	--------------------------------------------------
-	OOPS!!! Invalid task selected!
+	OOPS!!! `delete` command expects a single number argument (e.g. `delete 1`)
 	--------------------------------------------------
 	--------------------------------------------------
 	Got it. I've added this task:


### PR DESCRIPTION
## Description

As per title, instead of utilizing manual tokenization for command checking, `regex` is used. This allows for more expressive checks and simplier code structure.

**Other changes**

- Improved error messages
    - Shows users the proper format for commands (e.g. `deadline`, `event`) when given command fails validation checks 